### PR TITLE
gradio fix

### DIFF
--- a/install.js
+++ b/install.js
@@ -15,7 +15,7 @@ module.exports = {
         path: "app",
         message: [
           "uv pip install -r pyproject.toml",
-          "uv pip install huggingface_hub==0.36.0 hf-xet"
+          "uv pip install huggingface_hub==0.36.0 hf-xet gradio==5.50.0"
         ]
       }
     },


### PR DESCRIPTION
pin gradio 5.50.0 because gradio 6.x causes an av error.
"ValueError: File object has no read() method, or readable() returned False."